### PR TITLE
Add optional wheel event listener

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -52,6 +52,7 @@ export type TOptions = {
   spacing?: number
   vertical?: boolean
   inlineBlockMode?: boolean
+  deactivateWheelEvent?: boolean
 }
 
 export type TEvents = {

--- a/src/keen-slider.js
+++ b/src/keen-slider.js
@@ -159,25 +159,15 @@ function KeenSlider(initialContainer, initialOptions = {}) {
   }
 
   function eventsAdd() {
-    const isEventPassive = !(!isTouchable() || !touchActive)
-
     eventAdd(window, 'orientationchange', sliderResizeFix)
     eventAdd(window, 'resize', () => sliderResize())
-    eventAdd(container, 'dragstart', function (e) {
-      if (!isTouchable()) return
-      e.preventDefault()
-    }, {passive: isEventPassive})
     eventAdd(container, 'mousemove', eventDrag)
+    eventAdd(container, 'mouseleave', eventDragStop)
+    eventAdd(container, 'mouseup', eventDragStop)
     eventAdd(container, 'mousedown', eventDragStart, {
       passive: true,
     })
     eventAdd(container, 'touchstart', eventDragStart, {
-      passive: true,
-    })
-    eventAdd(container, 'mouseleave', eventDragStop, {
-      passive: true,
-    })
-    eventAdd(container, 'mouseup', eventDragStop, {
       passive: true,
     })
     eventAdd(container, 'touchend', eventDragStop, {
@@ -187,11 +177,14 @@ function KeenSlider(initialContainer, initialOptions = {}) {
       passive: true,
     })
     eventAdd(container, 'touchmove', eventDrag, {
-      passive: isEventPassive,
+      passive: false,
     })
-    eventAdd(window, 'wheel', eventWheel, {
-      passive: isEventPassive,
-    })
+    
+    if (!!initialOptions.deactivateWheelEvent) {
+      eventAdd(window, 'wheel', eventWheel, {
+        passive: false,
+      })
+    }
   }
 
   function eventsRemove() {


### PR DESCRIPTION
Keen-slider's code implement a listener for the wheel event by default that we want to deactivate in our case.
This should be enough to fix our current problems with the carousel performances.